### PR TITLE
Basic Travis with GCC 5 + LLVM 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: false
+language: cpp
+
+matrix:
+  include:
+
+    - env: COMPILER_VERSION=3.7
+      compiler: clang
+      addons: &clang36
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
+          packages: ['clang-3.7']
+
+    - env: COMPILER_VERSION=5
+      compiler: gcc
+      addons: &gcc5
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+
+before_install:
+  - export CC="${CC}-${COMPILER_VERSION}"
+  - export CXX="${CXX}-${COMPILER_VERSION}"
+
+script:
+  - cd Test
+  - ./test.sh
+  - ./test_depending_ptr.sh
+
+notifications:
+  email: false


### PR DESCRIPTION
Travis may support newer versions, we can try them later.